### PR TITLE
import で絶対パスを使用する

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "tsx": "^4.7.3",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
+    "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.4.0"
   },
   "resolutions": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Dashboard } from "./components/layouts/Dashboard";
+import { Dashboard } from "@/components/layouts/Dashboard";
 
 function App() {
   return (

--- a/src/components/atoms/Button/Button.stories.tsx
+++ b/src/components/atoms/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
+import { Button } from "@/components/atoms/Button/Button";
 import type { Meta, StoryFn, StoryObj } from "@storybook/react";
-import { Button } from ".";
 import styled from "styled-components";
 
 const meta = {

--- a/src/components/atoms/IconButton/IconButton.stories.tsx
+++ b/src/components/atoms/IconButton/IconButton.stories.tsx
@@ -1,5 +1,5 @@
+import { IconButton } from "@/components/atoms/IconButton/IconButton";
 import type { Meta, StoryObj } from "@storybook/react";
-import { IconButton } from ".";
 
 const meta = {
   title: "atoms/IconButton",

--- a/src/components/atoms/IconButton/IconButton.tsx
+++ b/src/components/atoms/IconButton/IconButton.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, FC } from "react";
 import styled from "styled-components";
-import { Icon } from "../Icon";
+import { Icon } from "@/components/atoms/Icon";
 
 type Props = {
   className?: string;

--- a/src/components/layouts/Dashboard/Dashboard.tsx
+++ b/src/components/layouts/Dashboard/Dashboard.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import { Header } from "../Header";
-import { Sidebar } from "../Sidebar";
-import { Main } from "../../pages/main";
-import { menus } from "../../../routes/navigation";
+import { Header } from "@/components/layouts/Header";
+import { Sidebar } from "@/components/layouts/Sidebar";
+import { Main } from "@/components/pages/main";
+import { menus } from "@/routes/navigation";
 import { FC } from "react";
 
 export const Dashboard: FC = () => {

--- a/src/components/layouts/Header/Header.stories.tsx
+++ b/src/components/layouts/Header/Header.stories.tsx
@@ -1,5 +1,5 @@
+import { Header } from "@/components/layouts/Header/Header";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Header } from ".";
 
 const meta = {
   title: "layouts/Header",

--- a/src/components/layouts/Header/Header.tsx
+++ b/src/components/layouts/Header/Header.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import styled from "styled-components";
-import { IconButton } from "../../atoms/IconButton";
+import { IconButton } from "@/components/atoms/IconButton";
 import * as Avatar from "@radix-ui/react-avatar";
 
 type Props = {

--- a/src/components/layouts/Sidebar/Sidebar.stories.tsx
+++ b/src/components/layouts/Sidebar/Sidebar.stories.tsx
@@ -1,5 +1,5 @@
+import { Sidebar } from "@/components/layouts/Sidebar/Sidebar";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Sidebar } from ".";
 
 const meta = {
   title: "layouts/Sidebar",

--- a/src/components/layouts/Sidebar/Sidebar.tsx
+++ b/src/components/layouts/Sidebar/Sidebar.tsx
@@ -1,10 +1,10 @@
 import type { FC } from "react";
 import styled from "styled-components";
-import { Icon } from "../../atoms/Icon";
-import { Menu } from "../../molecules/Menu";
+import { Icon } from "@/components/atoms/Icon";
+import { Menu } from "@/components/molecules/Menu";
 import { Link } from "wouter";
-import { paths } from "../../../routes/path";
-import { Menus } from "../../../routes/navigation";
+import { paths } from "@/routes/path";
+import type { Menus } from "@/routes/navigation";
 
 type Props = {
   className?: string;

--- a/src/components/molecules/Card/Card.stories.tsx
+++ b/src/components/molecules/Card/Card.stories.tsx
@@ -1,5 +1,5 @@
+import { Card } from "@/components/molecules/Card/Card";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Card } from ".";
 
 const meta = {
   title: "molecules/Card",

--- a/src/components/molecules/Card/Card.tsx
+++ b/src/components/molecules/Card/Card.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import styled from "styled-components";
-import { Todo } from "../../../modules/todo/type";
-import { IconButton } from "../../atoms/IconButton";
+import type { Todo } from "@/modules/todo/type";
+import { IconButton } from "@/components/atoms/IconButton";
 
 type Props = {
   className?: string;

--- a/src/components/molecules/Menu/Menu.tsx
+++ b/src/components/molecules/Menu/Menu.tsx
@@ -1,8 +1,8 @@
 import type { FC } from "react";
 import styled from "styled-components";
-import { Icon } from "../../atoms/Icon";
+import { Icon } from "@/components/atoms/Icon";
 import { Link } from "wouter";
-import { Menus } from "../../../routes/navigation";
+import { Menus } from "@/routes/navigation";
 
 type Props = Menus[number];
 

--- a/src/components/pages/Todos/index.tsx
+++ b/src/components/pages/Todos/index.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
-import { useGetTodoListQuery } from "../../../modules/todo/api";
-import { Card } from "../../molecules/Card";
-import { LoadingSpinner } from "../../atoms/Loading";
+import { useGetTodoListQuery } from "@/modules/todo/api";
+import { Card } from "@/components/molecules/Card";
+import { LoadingSpinner } from "@/components/atoms/Loading";
 
 export const Todos = () => {
   const { data, error, isLoading } = useGetTodoListQuery("");

--- a/src/components/pages/main.tsx
+++ b/src/components/pages/main.tsx
@@ -1,7 +1,7 @@
 import { Route, Switch } from "wouter";
-import { paths } from "../../routes/path";
-import { Todos } from "./Todos";
+import { paths } from "@/routes/path";
 import { FC } from "react";
+import { Todos } from "@/components/pages/Todos";
 
 export const Main: FC = () => {
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,9 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import { GlobalStyle } from "./styles/global.ts";
 import { Provider } from "react-redux";
-import { store } from "./store.ts";
 import { ThemeProvider } from "styled-components";
-import { theme } from "./styles/variables.ts";
+import { store } from "@/store.ts";
+import { theme } from "@/styles/variables.ts";
 
 async function enableMocking() {
   if (process.env.NODE_ENV !== "development") {

--- a/src/modules/todo/api.ts
+++ b/src/modules/todo/api.ts
@@ -1,5 +1,5 @@
+import { Todo, TodosResponse } from "@/modules/todo/type";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { Todo, TodosResponse } from "./type";
 
 export const todoApi = createApi({
   reducerPath: "todoApi",

--- a/src/routes/navigation.ts
+++ b/src/routes/navigation.ts
@@ -1,4 +1,4 @@
-import { paths } from "./path";
+import { paths } from "@/routes/path";
 
 export const menus = [
   { title: "Home", to: `${paths.home}`, icon: "mdiHomeOutline" },

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
+import { todoApi } from "@/modules/todo/api";
 import { configureStore } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query";
-import { todoApi } from "./modules/todo/api";
 
 export const store = configureStore({
   reducer: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,12 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"],
+      "~/*": ["public/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   server: {
@@ -15,5 +16,6 @@ export default defineConfig({
         ],
       ],
     }),
+    tsconfigPaths(),
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,6 +5276,11 @@ globby@^13.1.2, globby@^13.2.2:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -8216,6 +8221,11 @@ ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
+tsconfck@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.0.3.tgz#d9bda0e87d05b1c360e996c9050473c7e6f8084f"
+  integrity sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==
+
 tsconfig-paths@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"
@@ -8542,6 +8552,15 @@ vite-node@1.4.0:
     pathe "^1.1.1"
     picocolors "^1.0.0"
     vite "^5.0.0"
+
+vite-tsconfig-paths@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz#321f02e4b736a90ff62f9086467faf4e2da857a9"
+  integrity sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    tsconfck "^3.0.3"
 
 vite@^5.0.0, vite@^5.2.0:
   version "5.2.8"


### PR DESCRIPTION
## Why

現状では相対パスを使用している。
ディレクトリの構造変更に影響されないように絶対パスを使用する。

## How

- [x] vite-tsconfig-paths を導入
- [x] vite.config.ts の設定を修正
- [x] 相対パスを置き換え